### PR TITLE
Trigger dark mode programmatically

### DIFF
--- a/front/app/dashboard/chat-box.tsx
+++ b/front/app/dashboard/chat-box.tsx
@@ -813,7 +813,7 @@ export default function ScrapeWidget({
     return () => window.removeEventListener("keydown", handleKeyDown);
   }, []);
 
-    const { setTheme } = useTheme()
+  const { setTheme } = useTheme()
 
   useEffect(() => {
     const handleMessage = (event: MessageEvent) => {


### PR DESCRIPTION
Allows you to send `iframe.postMessage("dark-mode", "*")` to the embed to switch to dark mode