### PR TITLE
feat/ docker images via Github CI

### DIFF
--- a/.github/workflows/build-docker.yml
+++ b/.github/workflows/build-docker.yml
@@ -51,7 +51,7 @@ jobs:
       - name: Extract metadata
         id: meta
         run: |
-          echo "commit_sha=${{ github.sha }}" >> $GITHUB_OUTPUT
+          echo "commit_sha=${GITHUB_SHA::7}" >> "$GITHUB_OUTPUT"
           echo "release_tag=${{ github.event.release.tag_name }}" >> $GITHUB_OUTPUT
           echo "is_prerelease=${{ github.event.release.prerelease }}" >> $GITHUB_OUTPUT
 


### PR DESCRIPTION
- Adds GitHub CI that runs on releases
- Adds "latest" tag if its a prod-ready release, if not, no "latest" tag gets added
- Commit SHA and Release tag get added as image tag
- Each individual Dockerfile gets its own image for organization
- GitHub CI always pushes to the current repo owner, allowing forks to also use this

(Docker-Compose file is currently in work and will follow with a seperate PR)